### PR TITLE
Fix mutate operation error on unlink

### DIFF
--- a/app/api/mcc-clients/unlink/route.ts
+++ b/app/api/mcc-clients/unlink/route.ts
@@ -52,19 +52,17 @@ export async function POST(request: NextRequest) {
       try {
         console.log(`🔓 Unlinking account ${accountId} from MCC ${mccId}`)
 
-        // First, get the customer client link resource name
+        // Create the customer client link resource name
         const customerClientLinkResourceName = `customers/${mccId}/customerClientLinks/${accountId}`
 
         console.log(`🔧 Removing customer client link: ${customerClientLinkResourceName}`)
 
-        // Use mutateResources with CustomerClientLink remove operation
-        const operations = [{
-          entity: 'customer_client_link',
-          operation: 'remove',
-          resource_name: customerClientLinkResourceName
-        }]
+        // Use the CustomerClientLinkService to remove the link
+        const operation = {
+          remove: customerClientLinkResourceName
+        }
 
-        const response = await mccCustomerClient.mutateResources(operations)
+        const response = await mccCustomerClient.customerClientLinks.mutate([operation])
 
         console.log(`✅ Successfully unlinked account ${accountId}`)
         


### PR DESCRIPTION
Fixes account unlinking by correcting the Google Ads API `CustomerClientLinkService` remove operation.

The previous implementation used `mutateResources` with an incorrect operation object, causing the "Mutate operations must have 'create', 'update', or 'remove' specified" error. This PR updates the API call to use `customerClientLinks.mutate()` with the correct `remove` operation format, as required by the Google Ads API.

---
<a href="https://cursor.com/background-agent?bcId=bc-dd9146df-6ae7-46ca-9d5b-433ec198ce92">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dd9146df-6ae7-46ca-9d5b-433ec198ce92">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>