### PR TITLE
Correct ad targeting for netherlands and dutch

### DIFF
--- a/lib/google-ads-client.ts
+++ b/lib/google-ads-client.ts
@@ -742,7 +742,12 @@ export async function createCampaign(
         'GB': 2826, // United Kingdom
         'AU': 2036, // Australia
         'DE': 2276, // Germany
-        'FR': 2250  // France
+        'FR': 2250, // France
+        'NL': 2528, // Netherlands
+        'nl': 2528, // Netherlands (lowercase)
+        'netherlands': 2528, // Netherlands (full name)
+        'NETHERLANDS': 2528, // Netherlands (uppercase)
+        '2528': 2528 // Netherlands (numeric geo target constant)
       }
 
       // Terminix targeting states (geo target constants)
@@ -783,13 +788,17 @@ export async function createCampaign(
           locationMutateOperations.push(...terminixOperations)
         } else {
           // Regular country targeting
+          const geoTargetId = locationCriteriaMap[location]
+          if (!geoTargetId) {
+            console.warn(`⚠️  Unknown location '${location}', defaulting to United States (2840). Available locations:`, Object.keys(locationCriteriaMap))
+          }
           locationMutateOperations.push({
             entity: "campaign_criterion",
             operation: "create",
             resource: {
               campaign: campaignResourceName,
               location: {
-                geo_target_constant: `geoTargetConstants/${locationCriteriaMap[location] || 2840}`
+                geo_target_constant: `geoTargetConstants/${geoTargetId || 2840}`
               }
             }
           })
@@ -820,16 +829,25 @@ export async function createCampaign(
         'es': 1003, // Spanish
         'fr': 1002, // French
         'de': 1001, // German
-        'it': 1004  // Italian
+        'it': 1004, // Italian
+        'nl': 1019, // Dutch
+        'dutch': 1019, // Dutch (full name)
+        'DUTCH': 1019, // Dutch (uppercase)
+        'NL': 1019   // Dutch (country code uppercase)
       }
 
+      const languageConstantId = languageCriteriaMap[campaignData.languageCode]
+      if (!languageConstantId) {
+        console.warn(`⚠️  Unknown language '${campaignData.languageCode}', defaulting to English (1000). Available languages:`, Object.keys(languageCriteriaMap))
+      }
+      
       const languageMutateOperations = [{
         entity: "campaign_criterion",
         operation: "create",
         resource: {
           campaign: campaignResourceName,
           language: {
-            language_constant: `languageConstants/${languageCriteriaMap[campaignData.languageCode] || 1000}`
+            language_constant: `languageConstants/${languageConstantId || 1000}`
           }
         }
       }]


### PR DESCRIPTION
Add Netherlands and Dutch to Google Ads client mappings to fix incorrect ad targeting.

Previously, the `createCampaign` function's location and language maps were missing entries for Netherlands and Dutch, causing campaigns to incorrectly default to United States and English even when specified. This PR adds comprehensive mapping entries and improves fallback logging.

---
<a href="https://cursor.com/background-agent?bcId=bc-35c293ad-8466-428f-95c3-b3bca73ff29c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-35c293ad-8466-428f-95c3-b3bca73ff29c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

