### PR TITLE
Fix Dutch language setting in Google Ads

### DIFF
--- a/lib/google-ads-client.ts
+++ b/lib/google-ads-client.ts
@@ -1013,8 +1013,12 @@ export async function createCampaign(
         'VI': 1045, 'VIETNAMESE': 1045
       }
 
-      const languageConstantId = languageCriteriaMap[campaignData.languageCode]
-      console.log(`🔍 Debug: languageCode '${campaignData.languageCode}' mapped to constant ID: ${languageConstantId}`)
+      const inputLanguageCode = String(campaignData.languageCode || '').trim()
+      const normalizedLanguageKey = inputLanguageCode.toLowerCase()
+      const languageConstantId = languageCriteriaMap[normalizedLanguageKey]
+        || languageCriteriaMap[inputLanguageCode]
+        || languageCriteriaMap[inputLanguageCode.toUpperCase()]
+      console.log(`🔍 Debug: languageCode '${campaignData.languageCode}' normalized to '${normalizedLanguageKey}' mapped to constant ID: ${languageConstantId}`)
       
       if (!languageConstantId) {
         console.warn(`⚠️  Unknown language '${campaignData.languageCode}', defaulting to English (1000).`)
@@ -1934,9 +1938,13 @@ export async function createDummyCampaign(
       }
       
       // Language constants: English = 1000, Dutch = 1019, Arabic = 1006, etc.
-      const languageConstantId = languageCriteriaMap[templateData.languageCode] || 1000
+      const inputLanguageCode = String(templateData.languageCode || '').trim()
+      const normalizedLanguageKey = inputLanguageCode.toLowerCase()
+      const languageConstantId = languageCriteriaMap[normalizedLanguageKey]
+        || languageCriteriaMap[inputLanguageCode]
+        || languageCriteriaMap[inputLanguageCode.toUpperCase()] || 1000
       
-      console.log(`🌐 Using language constant ${languageConstantId} for '${templateData.languageCode}'`)
+      console.log(`🌐 Using language constant ${languageConstantId} for '${templateData.languageCode}' (normalized: '${normalizedLanguageKey}')`)
       
       const languageOperations = [
         {


### PR DESCRIPTION
Harden Google Ads language mapping to correctly resolve language codes regardless of input casing or whitespace.

Previously, slight variations in `languageCode` input (e.g., 'nl ' or 'NL' instead of 'nl') could lead to incorrect language constant lookups, causing languages like Dutch to be misidentified as Arabic in Google Ads campaigns.

---
<a href="https://cursor.com/background-agent?bcId=bc-012c0bfa-93bc-4ba0-9507-7457f7cce0cf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-012c0bfa-93bc-4ba0-9507-7457f7cce0cf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

