### PR TITLE
Investigate suspended accounts API endpoint inconsistency

### DIFF
--- a/app/api/cache/mcc/suspended/refresh/route.ts
+++ b/app/api/cache/mcc/suspended/refresh/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth/next'
 import { authOptions } from '../../../../auth/[...nextauth]/route'
 import { GoogleAdsApi } from 'google-ads-api'
-import { upsertAccounts, setMeta, HIDDEN_ACCOUNT_IDS } from '@/lib/mcc-cache'
+import { replaceAccounts, setMeta, HIDDEN_ACCOUNT_IDS } from '@/lib/mcc-cache'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
@@ -85,7 +85,7 @@ export async function POST(request: NextRequest) {
     })
 
     const filteredRows = cachedRows.filter(r => !HIDDEN_ACCOUNT_IDS.includes(r.accountId))
-    await upsertAccounts(mccId, filteredRows)
+    await replaceAccounts(mccId, filteredRows)
 
     const counts = {
       total: filteredRows.length,


### PR DESCRIPTION
Implement cache synchronization for suspended accounts and add UI auto-refresh to prevent stale data.

The previous refresh mechanism only added or updated existing accounts, leading to "ghost" suspended accounts appearing on the dashboard that were no longer suspended in Google Ads. This change ensures the cache accurately reflects the current state by removing accounts not present in the latest snapshot and triggers a refresh if the cached data is too old.

---
<a href="https://cursor.com/background-agent?bcId=bc-fb6e1326-6534-4929-8e4c-05ed4510ac1c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fb6e1326-6534-4929-8e4c-05ed4510ac1c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

